### PR TITLE
format PEP8, remove tags, and fix xline

### DIFF
--- a/cite_clustering.py
+++ b/cite_clustering.py
@@ -1,81 +1,105 @@
-import requests, os, datetime, argparse
-from bs4 import BeautifulSoup
-import matplotlib.pyplot as plt
-import pandas as pd
-from time import sleep
-import warnings,re
-from matplotlib import pyplot as plt
+import argparse
+import csv
+import datetime
+import difflib
+import os
+import pprint
+import re
 import time
 import timeit
+import warnings
+from time import sleep
+
+import matplotlib.pyplot as plt
+import matplotlib.ticker as ticker
 import numpy as np
-import difflib
+import pandas as pd
+import requests
+from bs4 import BeautifulSoup
 from sklearn.linear_model import LinearRegression
-import csv
-import pprint
+
+
 def get_conf(keyword0, key_conf, conference):
-    keyword = keyword0.replace(' ', '+')
+    keyword = keyword0.replace(" ", "+")
     number = 10
-    html_doc = requests.get("https://scholar.google.co.jp/scholar?hl=ja&as_sdt=0%2C5as_vis=1&num=" + str(number) + "&q=" + keyword + "+" + key_conf).text
+    html_doc = requests.get(
+        "https://scholar.google.co.jp/scholar?hl=ja&as_sdt=0%2C5as_vis=1&num="
+        + str(number)
+        + "&q="
+        + keyword
+        + "+"
+        + key_conf
+    ).text
     soup = BeautifulSoup(html_doc, "html.parser")
     tags1 = soup.find_all("h3", {"class": "gs_rt"})
     tags2 = soup.find_all("div", {"class": "gs_a"})
-    tags3 = soup.find_all(text=re.compile("引用元")) 
+    tags3 = soup.find_all(text=re.compile("引用元"))
     tags4 = soup.find_all("div", {"class": "gs_fl"})
     thre_diff = 0.1
     title_list = []
-    conf_list =[]
+    conf_list = []
     year_list = []
     p_id_list = []
     ci_num_list = []
     for i in range(number):
         conf = tags2[i].text
-        year = re.sub(r'\D', '', conf)
-        conf = re.sub(r'\d', '', conf)
+        year = re.sub(r"\D", "", conf)
+        conf = re.sub(r"\d", "", conf)
         diff = difflib.SequenceMatcher(None, conf, conference).ratio()
         if diff > thre_diff:
             conf_list.append(i)
             year_list.append(int(year[0:4]))
-    tags3 = soup.find_all(text=re.compile("引用元")) 
+    tags3 = soup.find_all(text=re.compile("引用元"))
     for i in conf_list:
-        citations = tags3[i].replace("引用元","")
+        citations = tags3[i].replace("引用元", "")
         ci_num_list.append(int(citations))
-        title_list.append(tags1[i].text.replace("[HTML]",""))
+        # PDF, 書籍, B, HTML のタグを除去
+        title = re.sub(r"\[(PDF|書籍|B|HTML)\]", "", tags1[i].text)
+        # 空白区切りを廃止
+        title = "_".join(title.split(" "))
+        # 空欄で始まる場合は詰める
+        if title[0] == "_":
+            title = title[1:]
+        title_list.append(title)
         try:
-            elem = elem = tags4[i*2+1].find_all('a')[2]['href']
+            elem = elem = tags4[i * 2 + 1].find_all("a")[2]["href"]
             a = 15
             while True:
-                if elem[a] == '&':
+                if elem[a] == "&":
                     break
-                a+=1
+                a += 1
             p_id_list.append(elem[15:a])
         except:
-            print('')   
-    cite_years, citations = get_cite(conf_list, title_list, year_list, ci_num_list, p_id_list)
+            print("")
+    cite_years, citations = get_cite(
+        conf_list, title_list, year_list, ci_num_list, p_id_list
+    )
     return cite_years, citations
+
 
 def get_cite(conf_list, title_list, year_list, ci_num_list, p_id_list):
     for i in range(len(conf_list)):
-        print('paper number: ' + str(i))
-        print('論文タイトル: ' + title_list[i])
-        print('発行年: ' + str(year_list[i]))
-        print('被引用回数: ' + str(ci_num_list[i]))
-        print('----------------------------------')
-    num = input('Select paper number: ')
+        print("paper number: " + str(i))
+        print("論文タイトル: " + title_list[i])
+        print("発行年: " + str(year_list[i]))
+        print("被引用回数: " + str(ci_num_list[i]))
+        print("----------------------------------")
+    num = input("Select paper number: ")
     num = int(num)
 
     sleep(1)
-    #引用論文発行年獲得、listに格納
-    base_url = 'https://scholar.google.com/scholar?start={}&hl=ja&as_sdt=2005&sciodt=0,5&cites={}&scipsc='
-    year = year_list[num] #対象論文発行年
+    # 引用論文発行年獲得、listに格納
+    base_url = "https://scholar.google.com/scholar?start={}&hl=ja&as_sdt=2005&sciodt=0,5&cites={}&scipsc="
+    year = year_list[num]  # 対象論文発行年
     ci_num = ci_num_list[num]
     title = title_list[num]
     if ci_num > 100:
-        ci_num  = input("Number of citations: ")
+        ci_num = input("Number of citations: ")
         ci_num = int(ci_num)
     p_id = p_id_list[num]
 
-    count = [0 for i in range(2020-year+1)] #発行年から2020年までの引用数格納用のlist作成
-    #c = 0
+    count = [0 for i in range(2020 - year + 1)]  # 発行年から2020年までの引用数格納用のlist作成
+    # c = 0
     for n in range(0, ci_num, 10):
         url = base_url.format(str(n), p_id)
         html_doc = requests.get(url).text
@@ -88,17 +112,17 @@ def get_cite(conf_list, title_list, year_list, ci_num_list, p_id_list):
             if len(result) == 0:
                 continue
             if len(result) == 1:
-              p_year = int(float(result[0])) #対象論文を引用した論文の発行年 p_year
-            
+                p_year = int(float(result[0]))  # 対象論文を引用した論文の発行年 p_year
+
             flag = True
             if len(result) > 1:
-              for r in result:
-                if len(r) == 4 and int(float(r)) >= year and  int(float(r)) <= 2020:
-                  p_year = int(float(r))
-                  flag = False
-                  break
-              if flag:
-               continue
+                for r in result:
+                    if len(r) == 4 and int(float(r)) >= year and int(float(r)) <= 2020:
+                        p_year = int(float(r))
+                        flag = False
+                        break
+                if flag:
+                    continue
 
             if p_year - year < 0:
                 continue
@@ -108,19 +132,20 @@ def get_cite(conf_list, title_list, year_list, ci_num_list, p_id_list):
 
         sleep(1)
 
-    x = [[year+i] for i in range(2020-year+1)] #対象論文発行年から2020年までを要素として持つリスト作成
+    x = [[year + i] for i in range(2020 - year + 1)]  # 対象論文発行年から2020年までを要素として持つリスト作成
 
-    #plt.plot(x, count)
-    #plt.xlabel("引用年")
-    #plt.ylabel("引用数")
+    # plt.plot(x, count)
+    # plt.xlabel("引用年")
+    # plt.ylabel("引用数")
 
-    #plt.show()
-    #print(c)
+    # plt.show()
+    # print(c)
     plot_citations(title, year, count)
-    #print(x) #countに対応する年
-    #print(count) #各年毎の引用数
+    # print(x) #countに対応する年
+    # print(count) #各年毎の引用数
 
     return x, count
+
 
 def fit_reg(cite_years, citations, reg):
     """fit a regression model to cumulative_citations
@@ -143,6 +168,8 @@ def plot_citations(title, cite_years, citations):
     plt.ylabel("citations")
     plt.title(title)
     plt.xlim(cite_years, 2020)
+    plt.gca().get_xaxis().get_major_formatter().set_useOffset(False)
+    plt.gca().get_xaxis().set_major_locator(ticker.MaxNLocator(integer=True))
     plt.plot(range(cite_years, 2021), citations)
     plt.savefig(f"{title}.png")
     return
@@ -155,7 +182,7 @@ cite_years, citations = get_conf(keyword0, key_conf, conference)
 coef = fit_reg(cite_years, citations, reg=LinearRegression())
 print(f"coef: {coef}")
 cite_years = [i[0] for i in cite_years]
-with open('cite_years.csv', 'w') as f:
+with open("cite_years.csv", "w") as f:
     writer = csv.writer(f)
     writer.writerow(cite_years)
     writer.writerow(citations)


### PR DESCRIPTION
以下の変更を行いました。手元では問題なく動いています。
* コードが長くなってきたので、Black と Isort でコード本文と import の順番を PEP8 のフォーマットに合わせました
* タイトルに [HTML] などのタグが残っていたので、削除し、空白区切りを '_' で結合しました
* グラフの横軸（年）が実数だったので、matplotlib の ticker で整数に固定しました

よろしくお願いします。