### PR TITLE
add paper id to make_url, and create grep_candidate_papers

### DIFF
--- a/scraping_utils.py
+++ b/scraping_utils.py
@@ -33,7 +33,7 @@ def make_url(keyword, conf, author, paper_id=None):
     ), "KeywordNotFoundError"
     url = "https://scholar.google.co.jp/scholar?"
     if paper_id is not None:
-        url += f"cites={paper_id}"
+        url += f"&cites={paper_id}"
     else:
         url += "&as_sdt=0%2C5"
         if keyword is not None:
@@ -251,6 +251,7 @@ def write_csv(conf, title_list, url_list, writer_list, year_list, ci_num_list, p
 
 if __name__ == "__main__":
     conf = "ICASSP"
+    conf = 'Meeting of the Association for Computational Linguistics (ACL)'	
     url = make_url(keyword=None, conf=conf, author=None)
     print(f"url: {url}")
 


### PR DESCRIPTION
* `make_url` に 論文id を有効にしました。これにより、以下の2種類の url を生成できます。
  * keyword, author, conf から検索を行うための url
  * paper id より対象の論文を引用している論文を検索する url
* ある論文を引用している論文を検索したい場合 論文id が必要なのですが、検索しないとわからない情報なので、`grep_candidate_papers` 関数を作成しました。
  * keyword, author, conf から生成した通常検索のための url から上位10件の論文情報を取得
  * 得られた10件の論文の情報を表示
  * 引用論文を調べたい対象の論文の番号を入力（0〜9以外の数字が入力された場合 Index out of range が出て、0〜9の数字が入力されるまで再入力を求めます）
  * 選択した論文の情報（タイトル、著者、出版年、引用数、url、論文id、スニペット）を辞書形式で返す

あとは、得られた対象論文の情報 `target_paper['paper_id']` から url を作成し、`scraping_papers` 関数に与えれば対象論文を引用している論文100件の情報を獲得できます。